### PR TITLE
Fixing compiling error

### DIFF
--- a/src/ysclass/src/yshash.h
+++ b/src/ysclass/src/yshash.h
@@ -2744,6 +2744,7 @@ public:
 		if(YSOK!=RewindElemEnumHandle(hd))
 		{
 			hd=NullHandle();
+			return hd;
 		}
 	}
     inline YsFixedLengthToMultiHashElemEnumHandle Null(void) const


### PR DESCRIPTION
In the beginning of compilation as a part of Tsugaru, the process crashes with "Some warnings being treated as errors" message.