### PR TITLE
OpenGL MSAA & RemakePolygonBuffer optimization

### DIFF
--- a/src/fssimplewindow/src/windows/fswin32wrapper.cpp
+++ b/src/fssimplewindow/src/windows/fswin32wrapper.cpp
@@ -140,6 +140,7 @@ static bool FsWin32IsWindowActive(void)
 
 // For OpenGL set up >>
 static int doubleBuffer=0;
+static bool useMSAA = false;
 // For OpenGL set up <<
 
 
@@ -181,7 +182,7 @@ void FsOpenWindow(const FsOpenWindowOption &opt)
 	int wid=opt.wid;
 	int hei=opt.hei;
 	int useDoubleBuffer=(int)opt.useDoubleBuffer;
-	// int useMultiSampleBuffer==(int)opt.useMultiSampleBuffer;
+	useMSAA = opt.useMultiSampleBuffer;
 	const char *windowName=opt.windowTitle;
 
 	if(NULL!=fsWin32Internal.hWnd)
@@ -658,8 +659,16 @@ static LRESULT WINAPI WindowFunc(HWND hWnd,UINT msg,WPARAM wp,LPARAM lp)
 			break;
 		}
 		fsWin32Internal.hDC=GetDC(hWnd);
-		//YsSetPixelFormat(fsWin32Internal.hDC);
-		YsSetPixelFormatARB(fsWin32Internal.hDC);
+
+		//if antialiasing is set via config, enable MSAA via WGL extensions
+		if (useMSAA)
+		{
+			YsSetPixelFormatARB(fsWin32Internal.hDC);
+		}
+		else
+		{
+			YsSetPixelFormat(fsWin32Internal.hDC);
+		}
 		fsWin32Internal.hRC=wglCreateContext(fsWin32Internal.hDC);
 		wglMakeCurrent(fsWin32Internal.hDC,fsWin32Internal.hRC);
 		if(0==doubleBuffer)

--- a/src/ysclass/src/ysmath.h
+++ b/src/ysclass/src/ysmath.h
@@ -90,6 +90,9 @@ inline void YsMakeSmaller(T &a,const T &b)
  */
 template <class T>
 inline const T YsBound(const T &x,const T &a,const T &b)
+/*! Ensures that the output is within the allowable range (between a and b) and if not returns the
+    nearest value that is actually in the range
+ */
 {
 	return ((x)<(a) ? (a) : ((x)>(b) ? (b) : (x)));
 }

--- a/src/ysgebl/src/kernel/ysshellextdrawbuffer.h
+++ b/src/ysgebl/src/kernel/ysshellextdrawbuffer.h
@@ -169,7 +169,9 @@ public:
 	void RemakeSelectedVertexBuffer(const class YsShellExt &shl,const double selectedVertexMarkerRadius,const YsArray <YsShellVertexHandle,N> &selVtHd);
 
 	void RemakePolygonBuffer(const ShapeInfo &shapeInfo,const double polygonShrinkRatioForPicking);
+	void RemakePolygonBufferSingleThreaded(const class YsShellExt& shl, const double polygonShrinkRatioForPicking);
 	void RemakePolygonBuffer(const class YsShellExt &shl,const double polygonShrinkRatioForPicking);
+	void RemakePolygonBufferSingleThreaded(const ShapeInfo& shapeInfo, const double polygonShrinkRatioForPicking);
 
 	void AddPolygonAsLight(const class YsShellExt &shl,const double lightSize);
 


### PR DESCRIPTION
- Adds multisample antialiasing to the Windows GL1 & GL2 renderers
- Rewrites RemakePolygonBuffer to run all of the buffer operations on the calling thread rather than spawning as many threads as the machine can support (this was causing performance issues)

