### PR TITLE
Fixes for FreeBSD and Arch Linux compatibility

### DIFF
--- a/src/fssimplewindow/src/glx/fsglxwrapper.cpp
+++ b/src/fssimplewindow/src/glx/fsglxwrapper.cpp
@@ -339,7 +339,7 @@ void FsResizeWindow(int newWid,int newHei)
 
 int FsCheckWindowOpen(void)
 {
-	if(ysXWnd!=NULL)
+	if(ysXWnd!=0)
 	{
 		return 1;
 	}
@@ -456,7 +456,7 @@ void FsSetWindowTitle(const char windowTitle[])
 
 void FsPollDevice(void)
 {
-	if(NULL==ysXWnd)
+	if(0==ysXWnd)
 	{
 		return;
 	}

--- a/src/fssimplewindow/src/nownd/fssimplenowindow.cpp
+++ b/src/fssimplewindow/src/nownd/fssimplenowindow.cpp
@@ -57,7 +57,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	#include <dirent.h>
 	#include <fcntl.h>
 	#include <unistd.h>
-	#include <termio.h>
+	#include <termios.h>
 	#include <stdio.h>
 	#include <stdlib.h>
 	#include <time.h>
@@ -74,7 +74,7 @@ static int mapFSKEYtoVK[FSKEY_NUM_KEYCODE];
 #ifdef __APPLE__
 static struct sgttyb OriginalConsoleSetting;
 #elif !defined(_WIN32)
-struct termio OriginalConsoleSetting;
+struct termios OriginalConsoleSetting;
 #endif
 
 
@@ -242,7 +242,7 @@ static void Restore(int)
 #elif defined(__APPLE__)
 	ioctl(fileno(stdin),TIOCSETP,&OriginalConsoleSetting);
 #else
-	ioctl(0,TCSETA,&OriginalConsoleSetting);
+	tcsetattr(0, TCSANOW, &OriginalConsoleSetting);
 #endif
 	printf("%s %d\n",__FUNCTION__,__LINE__);
 	exit(0);
@@ -263,14 +263,14 @@ static void FsSetUpInkeyConsole(void)
 	inkey.sg_flags&=~ECHO;
 	ioctl(fileno(stdin),TIOCSETP,&inkey);
 #else
-	struct termio inkey;
-	ioctl(0,TCGETA,&OriginalConsoleSetting);
+	struct termios inkey;
+	tcgetattr(0, &OriginalConsoleSetting);
 	inkey=OriginalConsoleSetting;
 	inkey.c_lflag&=~ECHO;
 	inkey.c_lflag&=~ICANON;
 	inkey.c_cc[VMIN]=0;   /* Zero wait */
 	inkey.c_cc[VTIME]=0;  /* Wait 0 second */
-	ioctl(0,TCSETA,&inkey);
+	tcsetattr(0, TCSANOW, &inkey);
 #endif
 }
 

--- a/src/yssocket/src/yssocket.cpp
+++ b/src/yssocket/src/yssocket.cpp
@@ -19,6 +19,7 @@ typedef int socklen_t;
 #else
 #include <unistd.h>
 #include <netdb.h>
+#include <netinet/in.h>
 #include <strings.h>
 #include <arpa/inet.h>
 #include <sys/types.h>

--- a/src/yssystemfont/src/linux/ysunixsystemfont.cpp
+++ b/src/yssystemfont/src/linux/ysunixsystemfont.cpp
@@ -66,7 +66,7 @@ YsSystemFontCache::InternalData::InternalData()
 	}
 
 	dsp=NULL;
-	rootWin=NULL;
+	rootWin=0;
 	fontSet=NULL;
 
 	dsp=XOpenDisplay(NULL);


### PR DESCRIPTION
Some small fixes that allow Tsugaru to build on FreeBSD and Arch Linux. I tried to make these changes in a way that other platforms' support is not disturbed.

- Use 0 instead of NULL when comparing with integer values, since NULL can be defined as `nullptr` or `(void*)0` on some platforms preventing comparison with integer types.
- Move from old termio.h interface to termios.h. FreeBSD and Arch no longer have the old termio.h header.
- Add missing includes